### PR TITLE
Fixed error with variable parsing

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install fail2ban
   yum: name={{ item }} state=present
-  with_items: fail2ban_packages
+  with_items: "{{ fail2ban_packages }}"
 - name: Configure fail2ban
   template: src={{ item.src }} dest={{ item.dest }}
             backup=yes mode=0644 owner=root group=root


### PR DESCRIPTION
Fixed error with variable expansion. Needs to be in double quotes and curly brackets. 
Ansible 2.2.1